### PR TITLE
Call json/generate-string for all kinds of collections

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -38,8 +38,7 @@
   [handler]
   (fn [request]
     (let [response (handler request)]
-      (if (or (map? (:body response))
-              (vector? (:body response)))
+      (if (coll? (:body response))
         (-> response
             (content-type "application/json")
             (update-in [:body] json/generate-string))

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -74,4 +74,16 @@
     (let [handler  (constantly {:status 200 :headers {} :body [:foo :bar]})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json"))
+      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+  
+  (testing "list body"
+    (let [handler  (constantly {:status 200 :headers {} :body '(:foo :bar)})
+          response ((wrap-json-response handler) {})]
+      (is (= (get-in response [:headers "Content-Type"]) "application/json"))
+      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+  
+  (testing "set body"
+    (let [handler  (constantly {:status 200 :headers {} :body #{:foo :bar}})
+          response ((wrap-json-response handler) {})]
+      (is (= (get-in response [:headers "Content-Type"]) "application/json"))
       (is (= (:body response) "[\"foo\",\"bar\"]")))))


### PR DESCRIPTION
json/generate-string will transform list and set into vector, so shouldn't be harmful accept all kinds of collections.

Tests are included.
