### PR TITLE
wrap-json-response now preserves Content-Type if already set

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -41,7 +41,8 @@
   (fn [request]
     (let [response (handler request)]
       (if (coll? (:body response))
-        (-> response
-            (content-type "application/json; charset=utf-8")
-            (update-in [:body] json/generate-string options))
+        (let [json-response (update-in response [:body] json/generate-string options)]
+          (if (contains? (:headers response) "Content-Type")
+            json-response
+            (content-type json-response "application/json; charset=utf-8")))
         response))))

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -92,4 +92,10 @@
     (let [handler  (constantly {:status 200 :headers {} :body {:foo "bar" :baz "quz"}})
           response ((wrap-json-response handler {:pretty true}) {})]
       (is (= (:body response)
-             "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}")))))
+             "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}"))))
+
+  (testing "don’t overwrite Content-Type if already set"
+    (let [handler  (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
+          response ((wrap-json-response handler) {})]
+      (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
+      (is (= (:body response) "{\"foo\":\"bar\"}")))))


### PR DESCRIPTION
My app sets the response header `Content-Type` and includes a parameter in the header value. Before this change, my header was being overwritten. This preserves the header if it’s already been set (it already exists in the response `:headers` map).
