### PR TITLE
add :keywords? option to wrap-json-params handler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring/ring-json "0.2.0"
+(defproject ring/ring-json "0.2.1"
   :description "Ring middleware for handling JSON"
   :url "https://github.com/ring-clojure/ring-json"
   :license {:name "The MIT License"

--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -24,9 +24,9 @@
   "Middleware that converts request bodies in JSON format to a map of
   parameters, which is added to the request map on the :json-params and
   :params keys."
-  [handler]
+  [handler & [{:keys [keywords?]}]]
   (fn [request]
-    (if-let [json (read-json request)]
+    (if-let [json (read-json request keywords?)]
       (handler (-> request
                    (assoc :json-params json)
                    (update-in [:params] merge json)))

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -23,12 +23,12 @@
             response (handler request)]
         (is (= {"foo" "bar"} (:body response))))))
 
-  (let [handler (wrap-json-body identity {:keywords? true})]
+  (let [handler (wrap-json-body identity :keywords? true)]
     (testing "keyword keys"
       (let [request  {:content-type "application/json"
                       :body (string-input-stream "{\"foo\": \"bar\"}")}
             response (handler request)]
-        (is (= {:foo "bar"} (:body response)))))))
+        (is (= {"foo" "bar"} (:body response)))))))
 
 (deftest test-json-params
   (let [handler  (wrap-json-params identity)]
@@ -56,6 +56,33 @@
             response (handler request)]
         (is (= {"id" 3, "foo" "bar"} (:params response)))
         (is (= {"foo" "bar"} (:json-params response)))))))
+
+(deftest test-json-params-with-keywords
+  (let [handler  (wrap-json-params identity {:keywords? true})]
+    (testing "xml body"
+      (let [request  {:content-type "application/xml"
+                      :body (string-input-stream "<xml></xml>")
+                      :params {"id" 3}}
+            response (handler request)]
+        (is (= "<xml></xml>") (slurp (:body response)))
+        (is (= {"id" 3} (:params response)))
+        (is (nil? (:json-params response)))))
+
+    (testing "json body"
+      (let [request  {:content-type "application/json; charset=UTF-8"
+                      :body (string-input-stream "{\"foo\": \"bar\"}")
+                      :params {"id" 3}}
+            response (handler request)]
+        (is (= {"id" 3, :foo "bar"} (:params response)))
+        (is (= {:foo "bar"} (:json-params response)))))
+
+    (testing "custom json body"
+      (let [request  {:content-type "application/vnd.foobar+json; charset=UTF-8"
+                      :body (string-input-stream "{\"foo\": \"bar\"}")
+                      :params {"id" 3}}
+            response (handler request)]
+        (is (= {"id" 3, :foo "bar"} (:params response)))
+        (is (= {:foo "bar"} (:json-params response)))))))
 
 (deftest test-json-response
   (testing "map body"


### PR DESCRIPTION
This patch allows to specify :keywors? argument to wrap-json-params handler

P.S. btw, why the explicity map is used for options like:

```
(wrap-json-params handler {:keywords true})
```

instead of more standard

```
(wrap-json-params handler :keywords true)
```

?
