### PR TITLE
Only merge maps into request/:params

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -26,11 +26,12 @@
   :params keys."
   [handler]
   (fn [request]
-    (if-let [json (read-json request)]
-      (handler (-> request
-                   (assoc :json-params json)
-                   (update-in [:params] merge json)))
-      (handler request))))
+    (let [json (read-json request)]
+      (if (and json (map? json))
+        (handler (-> request
+                     (assoc :json-params json)
+                     (update-in [:params] merge json)))
+        (handler request)))))
 
 (defn wrap-json-response
   "Middleware that converts responses with a map or a vector for a body into a

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -55,7 +55,14 @@
                       :params {"id" 3}}
             response (handler request)]
         (is (= {"id" 3, "foo" "bar"} (:params response)))
-        (is (= {"foo" "bar"} (:json-params response)))))))
+        (is (= {"foo" "bar"} (:json-params response)))))
+
+    (testing "array json body"
+      (let [request  {:content-type "application/vnd.foobar+json; charset=UTF-8"
+                      :body (string-input-stream "[\"foo\"]")
+                      :params {"id" 3}}
+            response (handler request)]
+        (is (= {"id" 3} (:params response)))))))
 
 (deftest test-json-response
   (testing "map body"


### PR DESCRIPTION
If a json array is passed in through the request body, merge fails with a

```
   java.lang.IllegalArgumentException: Vector arg to map conj must be a pair
```

This avoids trying the merge.
