### PR TITLE
Support optionally parsing all decimal numbers as bigdecimals

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ with a JSON content-type into a Clojure data structure:
   (response "Uploaded user."))
 
 (def app
-  (wrap-json-body handler {:keywords? true}))
+  (wrap-json-body handler {:keywords? true :use-bigdecimals? true}))
 ```
 
 

--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -1,6 +1,7 @@
 (ns ring.middleware.json
   (:use ring.util.response)
-  (:require [cheshire.core :as json]))
+  (:require [cheshire.core :as json]
+            [cheshire.parse :as parse]))
 
 (defn- json-request? [request]
   (if-let [type (:content-type request)]
@@ -14,11 +15,12 @@
 (defn wrap-json-body
   "Middleware that parses the :body of JSON requests into a Clojure data
   structure."
-  [handler & [{:keys [keywords?]}]]
+  [handler & [{:keys [keywords? use-bigdecimals?]}]]
   (fn [request]
-    (if-let [json (read-json request keywords?)]
-      (handler (assoc request :body json))
-      (handler request))))
+    (binding [parse/*use-bigdecimals?* use-bigdecimals?]
+      (if-let [json (read-json request keywords?)]
+        (handler (assoc request :body json))
+        (handler request)))))
 
 (defn wrap-json-params
   "Middleware that converts request bodies in JSON format to a map of

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -35,7 +35,15 @@
       (let [request  {:content-type "application/json"
                       :body (string-input-stream "{\"foo\": \"bar\"}")}
             response (handler request)]
-        (is (= {:foo "bar"} (:body response)))))))
+        (is (= {:foo "bar"} (:body response))))))
+
+  (let [handler (wrap-json-body identity {:keywords? true :use-bigdecimals? true})]
+    (testing "bigdecimal floats"
+      (let [request  {:content-type "application/json"
+                      :body (string-input-stream "{\"foo\": 5.5}")}
+            response (handler request)]
+        (is (decimal? (-> response :body :foo)))
+        (is (= {:foo 5.5M} (:body response)))))))
 
 (deftest test-json-params
   (let [handler  (wrap-json-params identity)]


### PR DESCRIPTION
Only `wrap-json-body`changed, it is up to debate if `wrap-json-params` should be changed as well.
