### PR TITLE
Use streamed responses instead of strings.

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -42,7 +42,8 @@
   (fn [request]
     (let [response (handler request)]
       (if (coll? (:body response))
-        (let [json-response (update-in response [:body] json/generate-string options)]
+        (let [json-response (update-in response [:body] json/generate-stream
+                                       (java.io.StringWriter.) options)]
           (if (contains? (:headers response) "Content-Type")
             json-response
             (content-type json-response "application/json; charset=utf-8")))

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -84,7 +84,7 @@
     (let [handler  (constantly {:status 200 :headers {} :body {:foo "bar"}})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "{\"foo\":\"bar\"}"))))
+      (is (= (.toString (:body response)) "{\"foo\":\"bar\"}"))))
 
   (testing "string body"
     (let [handler  (constantly {:status 200 :headers {} :body "foobar"})
@@ -96,28 +96,28 @@
     (let [handler  (constantly {:status 200 :headers {} :body [:foo :bar]})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+      (is (= (.toString (:body response)) "[\"foo\",\"bar\"]"))))
   
   (testing "list body"
     (let [handler  (constantly {:status 200 :headers {} :body '(:foo :bar)})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+      (is (= (.toString (:body response)) "[\"foo\",\"bar\"]"))))
   
   (testing "set body"
     (let [handler  (constantly {:status 200 :headers {} :body #{:foo :bar}})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
-      (is (= (:body response) "[\"foo\",\"bar\"]"))))
+      (is (= (.toString (:body response)) "[\"foo\",\"bar\"]"))))
 
   (testing "JSON options"
     (let [handler  (constantly {:status 200 :headers {} :body {:foo "bar" :baz "quz"}})
           response ((wrap-json-response handler {:pretty true}) {})]
-      (is (= (:body response)
+      (is (= (.toString (:body response))
              "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}"))))
 
   (testing "don’t overwrite Content-Type if already set"
     (let [handler  (constantly {:status 200 :headers {"Content-Type" "application/json; some-param=some-value"} :body {:foo "bar"}})
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
-      (is (= (:body response) "{\"foo\":\"bar\"}")))))
+      (is (= (.toString (:body response)) "{\"foo\":\"bar\"}")))))


### PR DESCRIPTION
Correct me where I am wrong but I was under the impression that using
streams instead of strings allows the webserver to stream the response
to the client more easily.
