### PR TITLE
Exception Handling For Malformed JSON In Body

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [cheshire "5.3.1"]
-                 [ring/ring-core "1.1.8"]]
+                 [ring/ring-core "1.1.8"]
+                 [com.fasterxml.jackson.core/jackson-core "2.3.1"]]
   :profiles
   {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
    :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -22,6 +22,26 @@
                       :body (string-input-stream "{\"foo\": \"bar\"}")}
             response (handler request)]
         (is (= {"foo" "bar"} (:body response)))))
+    
+    (testing "malformed json body"
+      (let [request-from-json (fn [json]
+                                {:content-type "application/json; charset=UTF-8"
+                                 :body (string-input-stream json)})]
+        (testing "non-closing tokens"
+          (let [json-string "{\"op\": \"add\"]"
+                request (request-from-json json-string)
+                response (handler request)]
+            (is (= 400 (:status response)))))
+        (testing "missing values"
+          (let [json-string "{\"op\":}"
+                request (request-from-json json-string)
+                response (handler request)]
+            (is (= 400 (:status response)))))
+        (testing "missing keys"
+          (let [json-string "{:\"op\"}"
+                request (request-from-json json-string)
+                response (handler request)]
+            (is (= 400 (:status response)))))))
 
     (testing "json patch body"
       (let [json-string "[{\"op\": \"add\",\"path\":\"/foo\",\"value\": \"bar\"}]"


### PR DESCRIPTION
- Returns status 400 for requests with malformed JSON in the body
- Fixes #7
