### PR TITLE
Fixing xml tests.

### DIFF
--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -9,7 +9,7 @@
       (let [request  {:headers {"content-type" "application/xml"}
                       :body (string-input-stream "<xml></xml>")}
             response (handler request)]
-        (is (= "<xml></xml>") (slurp (:body response)))))
+        (is (= "<xml></xml>" (slurp (:body response))))))
 
     (testing "json body"
       (let [request  {:headers {"content-type" "application/json; charset=UTF-8"}
@@ -79,7 +79,7 @@
                       :body (string-input-stream "<xml></xml>")
                       :params {"id" 3}}
             response (handler request)]
-        (is (= "<xml></xml>") (slurp (:body response)))
+        (is (= "<xml></xml>" (slurp (:body response))))
         (is (= {"id" 3} (:params response)))
         (is (nil? (:json-params response)))))
 


### PR DESCRIPTION
The xml tests were able to pass even with wrong strings because `is`
was receiving two string parameters instead of a single check.
The second parameter is a message, so it was calling:
`(is form msg)` instead of `(is form)`