### PR TITLE
Add support for key transforming functions when generating/parsing JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ This is the preferred way of handling JSON requests.
 ```
 
 
+#### Transforming JSON map keys
+
+Both `wrap-json-response` and `wrap-json-body` support the `:keywords?` option
+to automatically convert the keys of JSON maps to/from strings/keywords.
+Alternatively, a function can be provided which further customizes those keys:
+
+```clojure
+(use '[ring.middleware.json :only [wrap-json-body]]
+     '[ring.util.response :only [response]])
+
+(defn handler [request]
+  (prn (get-in request [:body "user"]))
+  (response "Uploaded user."))
+
+(def app
+  (wrap-json-body handler {:key-fn clojure.string/lower-case}))
+```
+
+Note: both `:key-fn` and `:keywords?` can be supplied at the same time. 
+
+
 #### wrap-json-params
 
 The `wrap-json-params` middleware is an alternative to

--- a/README.md
+++ b/README.md
@@ -52,11 +52,10 @@ This is the preferred way of handling JSON requests.
 ```
 
 
-#### Transforming JSON map keys
+##### Transforming JSON map keys
 
-Both `wrap-json-response` and `wrap-json-body` support the `:keywords?` option
-to automatically convert the keys of JSON maps to/from strings/keywords.
-Alternatively, a function can be provided which further customizes those keys:
+Both `wrap-json-response` and `wrap-json-body` support the `:key-fn` option
+which takes a transform function in order to customize the JSON map keys:
 
 ```clojure
 (use '[ring.middleware.json :only [wrap-json-body]]
@@ -70,7 +69,7 @@ Alternatively, a function can be provided which further customizes those keys:
   (wrap-json-body handler {:key-fn clojure.string/lower-case}))
 ```
 
-Note: both `:key-fn` and `:keywords?` can be supplied at the same time. 
+Note: for `wrap-json-body`, both `:key-fn` and `:keywords?` can be supplied at the same time. 
 
 
 #### wrap-json-params

--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -8,13 +8,20 @@
   (if-let [type (get-in request [:headers "content-type"])]
     (not (empty? (re-find #"^application/(.+\+)?json" type)))))
 
-(defn- read-json [request & [{:keys [keywords? bigdecimals?]}]]
+(defn- ->key-fn [key-fn keywords?]
+  (if (fn? key-fn)
+    (if keywords?
+      #(-> % key-fn keyword)
+      key-fn)
+    keywords?))
+
+(defn- read-json [request & [{:keys [key-fn keywords? bigdecimals?]}]]
   (if (json-request? request)
     (if-let [body (:body request)]
       (let [body-string (slurp body)]
         (binding [parse/*use-bigdecimals?* bigdecimals?]
           (try
-            [true (json/parse-string body-string keywords?)]
+            [true (json/parse-string body-string (->key-fn key-fn keywords?))]
             (catch com.fasterxml.jackson.core.JsonParseException ex
               [false nil])))))))
 
@@ -31,15 +38,16 @@
 
   Accepts the following options:
 
+  :key-fn             - a function to transform the keys of maps
   :keywords?          - true if the keys of maps should be turned into keywords
   :bigdecimals?       - true if BigDecimals should be used instead of Doubles
   :malformed-response - a response map to return when the JSON is malformed"
   {:arglists '([handler] [handler options])}
-  [handler & [{:keys [keywords? bigdecimals? malformed-response]
+  [handler & [{:keys [key-fn keywords? bigdecimals? malformed-response]
                :or {malformed-response default-malformed-response}}]]
   (fn [request]
     (if-let [[valid? json]
-             (read-json request {:keywords? keywords? :bigdecimals? bigdecimals?})]
+             (read-json request {:key-fn key-fn :keywords? keywords? :bigdecimals? bigdecimals?})]
       (if valid?
         (handler (assoc request :body json))
         malformed-response)
@@ -80,7 +88,8 @@
   Accepts the following options:
 
   :pretty            - true if the JSON should be pretty-printed
-  :escape-non-ascii  - true if non-ASCII characters should be escaped with \\u"
+  :escape-non-ascii  - true if non-ASCII characters should be escaped with \\u
+  :key-fn            - a function to transform the keys of maps in the JSON"
   {:arglists '([handler] [handler options])}
   [handler & [{:as options}]]
   (fn [request]

--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -12,11 +12,11 @@
   {:pre [(or (nil? key-fn) (fn? key-fn))]}
   (if (json-request? request)
     (if-let [body (:body request)]
-      (let [body-string (slurp body)
-            key-fn (if (and key-fn keywords?) #(-> % key-fn keyword) key-fn)]
+      (let [body-string (slurp body)]
         (binding [parse/*use-bigdecimals?* bigdecimals?]
           (try
-            [true (json/parse-string body-string (or key-fn keywords?))]
+            [true (json/parse-string body-string
+                                     (comp (if keywords? keyword identity) (or key-fn identity)))]
             (catch com.fasterxml.jackson.core.JsonParseException ex
               [false nil])))))))
 

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -1,5 +1,6 @@
 (ns ring.middleware.test.json
   (:require [clojure.test :refer :all]
+            [clojure.string :as str]
             [ring.middleware.json :refer :all]
             [ring.util.io :refer [string-input-stream]]))
 
@@ -45,14 +46,14 @@
             response (handler request)]
         (is (= {:foo "bar"} (:body response))))))
 
-  (let [handler (wrap-json-body identity {:key-fn clojure.string/upper-case})]
+  (let [handler (wrap-json-body identity {:key-fn str/upper-case})]
     (testing "transform keys"
       (let [request  {:headers {"content-type" "application/json"}
                       :body (string-input-stream "{\"foo\": \"bar\"}")}
             response (handler request)]
         (is (= {"FOO" "bar"} (:body response))))))
 
-  (let [handler (wrap-json-body identity {:key-fn clojure.string/upper-case
+  (let [handler (wrap-json-body identity {:key-fn str/upper-case
                                           :keywords? true})]
     (testing "transform keys with keywords"
       (let [request  {:headers {"content-type" "application/json"}
@@ -212,7 +213,7 @@
 
   (testing "JSON transform keys"
     (let [handler  (constantly {:status 200 :headers {} :body {:foo "bar" :baz "quz"}})
-          response ((wrap-json-response handler {:key-fn #(-> % name clojure.string/upper-case)}) {})]
+          response ((wrap-json-response handler {:key-fn (comp str/upper-case name)}) {})]
       (is (or (= (:body response) "{\"FOO\":\"bar\",\"BAZ\":\"quz\"}")
               (= (:body response) "{\"BAZ\":\"quz\",\"FOO\":\"bar\"}")))))
 

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -60,6 +60,12 @@
             response (handler request)]
         (is (= {:FOO "bar"} (:body response))))))
 
+  (let [handler (wrap-json-body identity {:key-fn 123})]
+    (testing "bad transform keys arg"
+      (let [request  {:headers {"content-type" "application/json"}
+                      :body (string-input-stream "{\"foo\": \"bar\"}")}]
+        (is (thrown? AssertionError (handler request))))))
+
   (let [handler (wrap-json-body identity {:keywords? true :bigdecimals? true})]
     (testing "bigdecimal floats"
       (let [request  {:headers {"content-type" "application/json"}


### PR DESCRIPTION
Cheshire supports arbitrary functions that transform the map keys when going to/from JSON. This PR adds support for passing in such transformers (beyond the already-supported `:keywords?` option).
