### PR TITLE
Update to latest cheshire version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [cheshire "5.5.0"]
+                 [cheshire "5.6.3"]
                  [ring/ring-core "1.4.0"]]
   :plugins [[codox "0.8.13"]]
   :profiles


### PR DESCRIPTION
The cheshire version which is currenlty used does not encode Float values properly:

(json/generate-string (java.lang.Float. 4.9))
4.900000095367432

This makes wrap-json-response quite unusable for me. Luckily, this is already fixed in the latest cheshire version:

(json/generate-string (java.lang.Float. 4.9))
4.9
