### PR TITLE
Allowing body to be either string or stream

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -8,10 +8,15 @@
   (if-let [type (get-in request [:headers "content-type"])]
     (not (empty? (re-find #"^application/(.+\+)?json" type)))))
 
+(defn- body-as-string [request-body]
+  (if (string? request-body)
+    request-body
+    (slurp request-body)))
+
 (defn- read-json [request & [{:keys [keywords? bigdecimals?]}]]
   (if (json-request? request)
     (if-let [body (:body request)]
-      (let [body-string (slurp body)]
+      (let [body-string (body-as-string body)]
         (binding [parse/*use-bigdecimals?* bigdecimals?]
           (try
             [true (json/parse-string body-string keywords?)]

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -17,6 +17,12 @@
             response (handler request)]
         (is (= {"foo" "bar"} (:body response)))))
 
+    (testing "json body as string"
+      (let [request  {:headers {"content-type" "application/json; charset=UTF-8"}
+                      :body "{\"foo\": \"bar\"}"}
+            response (handler request)]
+        (is (= {"foo" "bar"} (:body response)))))
+
     (testing "custom json body"
       (let [request  {:headers {"content-type" "application/vnd.foobar+json; charset=UTF-8"}
                       :body (string-input-stream "{\"foo\": \"bar\"}")}


### PR DESCRIPTION
When this middleware is used together with other middlewares
it may run into a conflict trying to slurp the body.
If the other middleware already slurped the body and put the
resulting string back into the request the slurp in this middleware
fails.
This commit adds handling of string-type body.