### PR TITLE
Decode request body according to character-encoding header

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -2,7 +2,8 @@
   "Ring middleware for parsing JSON requests and generating JSON responses."
   (:require [cheshire.core :as json]
             [cheshire.parse :as parse]
-            [ring.util.response :refer [content-type]]))
+            [ring.util.response :refer [content-type]]
+            [ring.util.request :refer [character-encoding]]))
 
 (defn- json-request? [request]
   (if-let [type (get-in request [:headers "content-type"])]
@@ -11,7 +12,8 @@
 (defn- read-json [request & [{:keys [keywords? bigdecimals?]}]]
   (if (json-request? request)
     (if-let [body (:body request)]
-      (let [body-string (slurp body)]
+      (let [encoding (or (character-encoding request) "UTF-8")
+            body-string (slurp body :encoding encoding)]
         (binding [parse/*use-bigdecimals?* bigdecimals?]
           (try
             [true (json/parse-string body-string keywords?)]

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -36,7 +36,19 @@
         (is (= (handler request)
                {:status  400
                 :headers {"Content-Type" "text/plain"}
-                :body    "Malformed JSON in request body."})))))
+                :body    "Malformed JSON in request body."}))))
+
+    (testing "json body not UTF-8 encoded"
+      (let [request  {:headers {"content-type" "application/json; charset=UTF-16"}
+                      :body (string-input-stream "{\"foo\": \"bar\"}" "UTF-16")}
+            response (handler request)]
+        (is (= {"foo" "bar"} (:body response)))))
+
+    (testing "json body defaults to parse as UTF-8 encoded when not specified"
+      (let [request  {:headers {"content-type" "application/json;"}
+                      :body (string-input-stream "{\"foo\": \"bar\"}")}
+            response (handler request)]
+        (is (= {"foo" "bar"} (:body response))))))
 
   (let [handler (wrap-json-body identity {:keywords? true})]
     (testing "keyword keys"


### PR DESCRIPTION
fixes #49 

* current implementation always expects request bodies to  be UTF-8 encoded.

* this change will check the requests character encoding and parse accordingly.  If no character encoding is specified it will default to UTF-8