### PR TITLE
Allow array json bodies to become json-params

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -57,11 +57,15 @@
        (respond malformed-response)))))
 
 (defn- assoc-json-params [request json]
-  (if (map? json)
-    (-> request
-        (assoc :json-params json)
-        (update-in [:params] merge json))
-    request))
+  (cond-> request
+    (map? json)
+    (update-in [:params] merge json)
+
+    json
+    (assoc :json-params json)
+
+    :else
+    identity))
 
 (defn json-params-request
   "Parse the body of JSON requests into a map of parameters, which are added

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -189,7 +189,8 @@
                       :body (string-input-stream "[\"foo\"]")
                       :params {"id" 3}}
             response (handler request)]
-        (is (= {"id" 3} (:params response)))))
+        (is (= {"id" 3} (:params response)))
+        (is (= ["foo"] (:json-params response)))))
 
     (testing "malformed json"
       (let [request {:headers {"content-type" "application/json; charset=UTF-8"}


### PR DESCRIPTION
Currently, when using the `wrap-json-params` middleware, if the incoming json body for a request is valid json, but happens to be an array, the `body` will be consumed by the middleware, but nothing will be added to the `:json-params`.

This PR changes the behavior of the `assoc-json-params` fn to allow array json bodies to be added to the `:json-params` in the request. It does not add array bodies to the request `:params`, though.

We were recently bitten by this in a service where one of our endpoints needs to take in an array json body, and our handlers all look in `:json-params` for the data they need to fulfill the request. 