### PR TITLE
Add stream support for response body - StreamableResponseBody impl

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -2,6 +2,9 @@
   "Ring middleware for parsing JSON requests and generating JSON responses."
   (:require [cheshire.core :as json]
             [cheshire.parse :as parse]
+            [clojure.java.io :as io]
+            [ring.core.protocols :as ring-protocols]
+            [ring.util.io :as ring-io]
             [ring.util.response :refer [content-type]]
             [ring.util.request :refer [character-encoding]]))
 
@@ -100,12 +103,21 @@
        (handler request respond raise)
        (respond malformed-response)))))
 
+(defrecord JsonStreamingResponseBody [body options]
+  ring-protocols/StreamableResponseBody
+  (write-body-to-stream [_ _ output-stream]
+    (json/generate-stream body (io/writer output-stream) options)))
+
 (defn json-response
   "Converts responses with a map or a vector for a body into a JSON response.
   See: wrap-json-response."
   [response options]
   (if (coll? (:body response))
-    (let [json-resp (update-in response [:body] json/generate-string options)]
+    (let [generator (if (:stream? options)
+                      ->JsonStreamingResponseBody
+                      json/generate-string)
+          options (dissoc options :stream?)
+          json-resp (update-in response [:body] generator options)]
       (if (contains? (:headers response) "Content-Type")
         json-resp
         (content-type json-resp "application/json; charset=utf-8")))
@@ -118,7 +130,8 @@
   Accepts the following options:
 
   :pretty            - true if the JSON should be pretty-printed
-  :escape-non-ascii  - true if non-ASCII characters should be escaped with \\u"
+  :escape-non-ascii  - true if non-ASCII characters should be escaped with \\u
+  :stream?           - true to create JSON body as stream rather than string"
   {:arglists '([handler] [handler options])}
   [handler & [{:as options}]]
   (fn

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -1,6 +1,7 @@
 (ns ring.middleware.test.json
   (:require [clojure.test :refer :all]
             [ring.middleware.json :refer :all]
+            [ring.core.protocols :refer [write-body-to-stream]]
             [ring.util.io :refer [string-input-stream]]))
 
 (deftest test-json-body
@@ -336,6 +337,25 @@
           response ((wrap-json-response handler) {})]
       (is (= (get-in response [:headers "Content-Type"]) "application/json; some-param=some-value"))
       (is (= (:body response) "{\"foo\":\"bar\"}")))))
+
+(defn streamable->string [body]
+  (let [baos (java.io.ByteArrayOutputStream.)]
+    (write-body-to-stream body nil baos)
+    (.toString baos "utf-8")))
+
+(deftest test-json-response-streaming
+  (testing "streaming vector body"
+    (let [handler  (constantly {:status 200 :headers {} :body [:foo :bar]})
+          response ((wrap-json-response handler {:stream? true}) {})]
+      (is (= (get-in response [:headers "Content-Type"]) "application/json; charset=utf-8"))
+      (is (= (streamable->string (:body response)) "[\"foo\",\"bar\"]"))))
+
+  (testing "streaming map body with options"
+    (let [handler  (constantly {:status 200 :headers {} :body {:foo "bar" :baz "quz"}})
+          response ((wrap-json-response handler {:stream? true :pretty true}) {})]
+      (is (let [body (streamable->string (:body response))]
+            (or (= body "{\n  \"foo\" : \"bar\",\n  \"baz\" : \"quz\"\n}")
+                (= body "{\n  \"baz\" : \"quz\",\n  \"foo\" : \"bar\"\n}")))))))
 
 (deftest test-json-response-cps
   (testing "map body"


### PR DESCRIPTION
As previously trailed in issue #58 and discussed at length in PR #59, here is a version of the JSON streaming support patch reworked to use StreamableResponseBody rather than piped-io-stream.

Should all be pretty much as expected; had to add a helper fn to the tests to get the content out of the more opaque body.

Testing seems slightly faster with my simple large-scale harness but probably within the bounds of variance - certainly removing the copy thread of piped-io-stream can't have hurt.

Let me know if you need any more changes/polish!