### PR TITLE
Enable JSON parsing when headers have been coerced to keywords

### DIFF
--- a/src/ring/middleware/json.clj
+++ b/src/ring/middleware/json.clj
@@ -10,7 +10,8 @@
   (:import [java.io InputStream]))
 
 (defn- json-request? [request]
-  (if-let [type (get-in request [:headers "content-type"])]
+  (if-let [type (or (get-in request [:headers "content-type"])
+                    (get-in request [:headers :content-type]))]
     (not (empty? (re-find #"^application/(.+\+)?json" type)))))
 
 (defn- read-json [request & [{:keys [keywords? bigdecimals? key-fn]}]]

--- a/test/ring/middleware/test/json.clj
+++ b/test/ring/middleware/test/json.clj
@@ -18,6 +18,12 @@
             response (handler request)]
         (is (= {"foo" "bar"} (:body response)))))
 
+    (testing "json body with keyword headers"
+      (let [request  {:headers {:content-type "application/json; charset=UTF-8"}
+                      :body (string-input-stream "{\"foo\": \"bar\"}")}
+            response (handler request)]
+        (is (= {"foo" "bar"} (:body response)))))
+
     (testing "custom json body"
       (let [request  {:headers {"content-type" "application/vnd.foobar+json; charset=UTF-8"}
                       :body (string-input-stream "{\"foo\": \"bar\"}")}


### PR DESCRIPTION
I've put `wrap-json-body` after middleware that coerces my headers into keywords more than a few times, and I've always struggled to remember that while debugging.